### PR TITLE
Removing -lasound flag

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -132,7 +132,7 @@ if (process.platform === 'darwin') { // OSX
   //   sudo apt-get install freeglut3-dev
   //   sudo apt-get install libpulseaudio-dev
 
-  platformspecificargs = `"-lasound", "-lm", "-ldl", "-lpthread", "-lrt"`
+  platformspecificargs = `"-lm", "-ldl", "-lpthread", "-lrt"`
 } else if (process.platform === "win32") {
   platformspecificargs = `"-lopengl32", "-lgdi32", "-lwinmm", "-limm32", "-lole32", "-loleaut32", "-lversion", "-luuid"`;
 } else {


### PR DESCRIPTION
This seems to not be necessary and causes `libasound2-dev` or equivalent to need to be installed.
It seems like @jdeisenberg was helped by this patch here: https://github.com/Schmavery/reprocessing/issues/93

If our resident reprocessing linux expert @zploskey doesn't have any objections, I'll merge this 😛